### PR TITLE
Add filesystem access to Discord RPC socket

### DIFF
--- a/io.github.nokse22.high-tide.json
+++ b/io.github.nokse22.high-tide.json
@@ -12,7 +12,8 @@
         "--socket=wayland",
         "--socket=pulseaudio",
         "--filesystem=xdg-run/pipewire-0:ro",
-        "--filesystem=xdg-run/app/com.discordapp.Discord:create"
+        "--filesystem=xdg-run/app/com.discordapp.Discord:create",
+        "--filesystem=xdg-run/discord-ipc-0"
     ],
     "cleanup": [
         "/include",


### PR DESCRIPTION
Allow Discord RPC to work if Discord is installed as a Flatpak. 
This is the recommended way to do as per https://github.com/flathub/com.discordapp.Discord/wiki/Rich-Precense-(discord-rpc)

The wrapper described in that documentation isn't needed as pypresence natively handles flatpak'ed Discord (`app/com.discordapp.DiscordApp` is in [IPC pipe detection code](https://github.com/qwertyquerty/pypresence/blob/4e882c36d0f800c016c15977243ac9a49177095a/pypresence/utils.py#L40), so no symlink is needed)
  